### PR TITLE
Fixed V.transpose() to V.hermitian() in complex singular value decomposition

### DIFF
--- a/src/main/java/org/jblas/Singular.java
+++ b/src/main/java/org/jblas/Singular.java
@@ -62,7 +62,7 @@ public class Singular {
 
         NativeBlas.zgesvd('S', 'S', m, n, A.dup().data, 0, m, S.data, 0, U.data, 0, m, V.data, 0, min(m, n), rwork, 0);
 
-        return new ComplexDoubleMatrix[]{U, new ComplexDoubleMatrix(S), V.transpose()};
+        return new ComplexDoubleMatrix[]{U, new ComplexDoubleMatrix(S), V.hermitian()};
     }
 
     /**


### PR DESCRIPTION
The complex singular value decomposition of a matrix A is usually defined as

A = U S V*

where S is diagonal and U and V are unitary and V\* denote the Hermitian (conjugate) transpose of V.  In the existing implementation for ComplexDoubleMatrix JBlas was returning

A = U S V'

where V' is the usual transpose.  This is a one word fix since ComplexDoubleMatrix already had a .hermitian() method.  The error was not there for ComplexFloatMatrix, in this case the Hermitian transpose was correctly returned.
