### PR TITLE
Pull-Request for bugfix

### DIFF
--- a/src/main/java/org/jblas/DoubleMatrix.java
+++ b/src/main/java/org/jblas/DoubleMatrix.java
@@ -1230,12 +1230,12 @@ public class DoubleMatrix implements Serializable {
 
     /** Compute the row index of a linear index. */
     public int indexRows(int i) {
-        return i / rows;
+		return i - (indexColumns(i) * rows);
     }
 
     /** Compute the column index of a linear index. */
     public int indexColumns(int i) {
-        return i - indexRows(i) * rows;
+		return (int) Math.floor(i / rows);		
     }
 
     /** Get a matrix element (linear indexing). */


### PR DESCRIPTION
The calculation of row and column index back from a linear index
failed because of a mix-up in the functions. See git log for more details.

Thanks for this fantastic library!! :+1: 
