### PR TITLE
Optimize matrix constructor to avoid extra array allocation

### DIFF
--- a/src/main/java/org/jblas/ComplexDoubleMatrix.java
+++ b/src/main/java/org/jblas/ComplexDoubleMatrix.java
@@ -97,9 +97,7 @@ public class ComplexDoubleMatrix {
 	}
 	
 	public ComplexDoubleMatrix(double[] newData) {
-		this(newData.length/2);
-				
-		data = newData;
+		this(newData.length/2, 1, newData);
 	}
 
 	public ComplexDoubleMatrix(ComplexDouble[] newData) {
@@ -986,7 +984,7 @@ public class ComplexDoubleMatrix {
 		boolean[] array = new boolean[length];
 		
 		for (int i = 0; i < length; i++)
-			array[i] = get(i).isZero() ? false : true;
+			array[i] = !get(i).isZero();
 		
 		return array;
 	}
@@ -996,7 +994,7 @@ public class ComplexDoubleMatrix {
 		
 		for (int r = 0; r < rows; r++)
 			for (int c = 0; c < columns; c++)
-				array[r][c] = get(r, c).isZero() ? false : true;
+				array[r][c] = !get(r, c).isZero();
 				
 		return array;
 	}

--- a/src/main/java/org/jblas/ComplexFloatMatrix.java
+++ b/src/main/java/org/jblas/ComplexFloatMatrix.java
@@ -97,9 +97,7 @@ public class ComplexFloatMatrix {
 	}
 	
 	public ComplexFloatMatrix(float[] newData) {
-		this(newData.length/2);
-				
-		data = newData;
+		this(newData.length/2, 1, newData);
 	}
 
 	public ComplexFloatMatrix(ComplexFloat[] newData) {
@@ -986,7 +984,7 @@ public class ComplexFloatMatrix {
 		boolean[] array = new boolean[length];
 		
 		for (int i = 0; i < length; i++)
-			array[i] = get(i).isZero() ? false : true;
+			array[i] = !get(i).isZero();
 		
 		return array;
 	}
@@ -996,7 +994,7 @@ public class ComplexFloatMatrix {
 		
 		for (int r = 0; r < rows; r++)
 			for (int c = 0; c < columns; c++)
-				array[r][c] = get(r, c).isZero() ? false : true;
+				array[r][c] = !get(r, c).isZero();
 				
 		return array;
 	}

--- a/src/main/java/org/jblas/DoubleMatrix.java
+++ b/src/main/java/org/jblas/DoubleMatrix.java
@@ -60,6 +60,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * A general matrix class for <tt>double</tt> typed values.
@@ -292,6 +293,11 @@ public class DoubleMatrix implements Serializable {
     public static final DoubleMatrix EMPTY = new DoubleMatrix();
     static final long serialVersionUID = -1249281332731183060L;
 
+    // Precompile regex patterns
+    private static final Pattern SEMICOLON = Pattern.compile(";");
+    private static final Pattern WHITESPACES = Pattern.compile("\\s+");
+    private static final Pattern COMMA = Pattern.compile(",");
+
     /**************************************************************************
      *
      * Constructors and factory functions
@@ -339,8 +345,7 @@ public class DoubleMatrix implements Serializable {
     }
 
     public DoubleMatrix(double[] newData) {
-        this(newData.length);
-        data = newData;
+        this(newData.length, 1, newData);
     }
 
     /**
@@ -384,7 +389,7 @@ public class DoubleMatrix implements Serializable {
         this(data.size());
 
         int c = 0;
-        for (java.lang.Double d : data) {
+        for (double d : data) {
             put(c++, d);
         }
     }
@@ -400,16 +405,13 @@ public class DoubleMatrix implements Serializable {
      * for example "1 2 3; 4 5 6; 7 8 9".
      */
     public static DoubleMatrix valueOf(String text) {
-        String[] rowValues = text.split(";");
-
-        // process first line
-        String[] columnValues = rowValues[0].trim().split("\\s+");
+        String[] rowValues = SEMICOLON.split(text);
 
         DoubleMatrix result = null;
 
         // process rest
         for (int r = 0; r < rowValues.length; r++) {
-            columnValues = rowValues[r].trim().split("\\s+");
+          String[] columnValues = WHITESPACES.split(rowValues[r].trim());
 
             if (r == 0) {
                 result = new DoubleMatrix(rowValues.length, columnValues.length);
@@ -1441,7 +1443,7 @@ public class DoubleMatrix implements Serializable {
         boolean[] array = new boolean[length];
 
         for (int i = 0; i < length; i++) {
-            array[i] = get(i) != 0.0 ? true : false;
+            array[i] = get(i) != 0.0;
         }
 
         return array;
@@ -1453,7 +1455,7 @@ public class DoubleMatrix implements Serializable {
 
         for (int r = 0; r < rows; r++) {
             for (int c = 0; c < columns; c++) {
-                array[r][c] = get(r, c) != 0.0 ? true : false;
+                array[r][c] = get(r, c) != 0.0;
             }
         }
 
@@ -1474,7 +1476,7 @@ public class DoubleMatrix implements Serializable {
      */
     public class ElementsAsListView extends AbstractList<Double> implements ConvertsToDoubleMatrix {
 
-        private DoubleMatrix me;
+        private final DoubleMatrix me;
 
         public ElementsAsListView(DoubleMatrix me) {
             this.me = me;
@@ -1497,7 +1499,7 @@ public class DoubleMatrix implements Serializable {
 
     public class RowsAsListView extends AbstractList<DoubleMatrix> implements ConvertsToDoubleMatrix {
 
-        private DoubleMatrix me;
+        private final DoubleMatrix me;
 
         public RowsAsListView(DoubleMatrix me) {
             this.me = me;
@@ -1520,7 +1522,7 @@ public class DoubleMatrix implements Serializable {
 
     public class ColumnsAsListView extends AbstractList<DoubleMatrix> implements ConvertsToDoubleMatrix {
 
-        private DoubleMatrix me;
+        private final DoubleMatrix me;
 
         public ColumnsAsListView(DoubleMatrix me) {
             this.me = me;
@@ -2727,7 +2729,7 @@ public class DoubleMatrix implements Serializable {
         int rows = 0;
         int columns = -1;
         while ((line = is.readLine()) != null) {
-            String[] elements = line.split("\\s+");
+            String[] elements = WHITESPACES.split(line);
             int numElements = elements.length;
             if (elements[0].length() == 0) {
                 numElements--;
@@ -2753,7 +2755,7 @@ public class DoubleMatrix implements Serializable {
         DoubleMatrix result = new DoubleMatrix(rows, columns);
         int r = 0;
         while ((line = is.readLine()) != null) {
-            String[] elements = line.split("\\s+");
+            String[] elements = WHITESPACES.split(line);
             int firstElement = (elements[0].length() == 0) ? 1 : 0;
             for (int c = 0, cc = firstElement; c < columns; c++, cc++) {
                 result.put(r, c, Double.valueOf(elements[cc]));
@@ -2770,7 +2772,7 @@ public class DoubleMatrix implements Serializable {
         String line;
         int columns = -1;
         while ((line = is.readLine()) != null) {
-            String[] elements = line.split(",");
+            String[] elements = COMMA.split(line);
             int numElements = elements.length;
             if (elements[0].length() == 0) {
                 numElements--;

--- a/src/main/java/org/jblas/FloatMatrix.java
+++ b/src/main/java/org/jblas/FloatMatrix.java
@@ -60,6 +60,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * A general matrix class for <tt>float</tt> typed values.
@@ -292,6 +293,11 @@ public class FloatMatrix implements Serializable {
     public static final FloatMatrix EMPTY = new FloatMatrix();
     static final long serialVersionUID = -1249281332731183060L;
 
+    // Precompile regex patterns
+    private static final Pattern SEMICOLON = Pattern.compile(";");
+    private static final Pattern WHITESPACES = Pattern.compile("\\s+");
+    private static final Pattern COMMA = Pattern.compile(",");
+
     /**************************************************************************
      *
      * Constructors and factory functions
@@ -339,8 +345,7 @@ public class FloatMatrix implements Serializable {
     }
 
     public FloatMatrix(float[] newData) {
-        this(newData.length);
-        data = newData;
+        this(newData.length, 1, newData);
     }
 
     /**
@@ -384,7 +389,7 @@ public class FloatMatrix implements Serializable {
         this(data.size());
 
         int c = 0;
-        for (java.lang.Float d : data) {
+        for (float d : data) {
             put(c++, d);
         }
     }
@@ -400,16 +405,13 @@ public class FloatMatrix implements Serializable {
      * for example "1 2 3; 4 5 6; 7 8 9".
      */
     public static FloatMatrix valueOf(String text) {
-        String[] rowValues = text.split(";");
-
-        // process first line
-        String[] columnValues = rowValues[0].trim().split("\\s+");
+        String[] rowValues = SEMICOLON.split(text);
 
         FloatMatrix result = null;
 
         // process rest
         for (int r = 0; r < rowValues.length; r++) {
-            columnValues = rowValues[r].trim().split("\\s+");
+          String[] columnValues = WHITESPACES.split(rowValues[r].trim());
 
             if (r == 0) {
                 result = new FloatMatrix(rowValues.length, columnValues.length);
@@ -1441,7 +1443,7 @@ public class FloatMatrix implements Serializable {
         boolean[] array = new boolean[length];
 
         for (int i = 0; i < length; i++) {
-            array[i] = get(i) != 0.0f ? true : false;
+            array[i] = get(i) != 0.0f;
         }
 
         return array;
@@ -1453,7 +1455,7 @@ public class FloatMatrix implements Serializable {
 
         for (int r = 0; r < rows; r++) {
             for (int c = 0; c < columns; c++) {
-                array[r][c] = get(r, c) != 0.0f ? true : false;
+                array[r][c] = get(r, c) != 0.0f;
             }
         }
 
@@ -1474,7 +1476,7 @@ public class FloatMatrix implements Serializable {
      */
     public class ElementsAsListView extends AbstractList<Float> implements ConvertsToFloatMatrix {
 
-        private FloatMatrix me;
+        private final FloatMatrix me;
 
         public ElementsAsListView(FloatMatrix me) {
             this.me = me;
@@ -1497,7 +1499,7 @@ public class FloatMatrix implements Serializable {
 
     public class RowsAsListView extends AbstractList<FloatMatrix> implements ConvertsToFloatMatrix {
 
-        private FloatMatrix me;
+        private final FloatMatrix me;
 
         public RowsAsListView(FloatMatrix me) {
             this.me = me;
@@ -1520,7 +1522,7 @@ public class FloatMatrix implements Serializable {
 
     public class ColumnsAsListView extends AbstractList<FloatMatrix> implements ConvertsToFloatMatrix {
 
-        private FloatMatrix me;
+        private final FloatMatrix me;
 
         public ColumnsAsListView(FloatMatrix me) {
             this.me = me;
@@ -2727,7 +2729,7 @@ public class FloatMatrix implements Serializable {
         int rows = 0;
         int columns = -1;
         while ((line = is.readLine()) != null) {
-            String[] elements = line.split("\\s+");
+            String[] elements = WHITESPACES.split(line);
             int numElements = elements.length;
             if (elements[0].length() == 0) {
                 numElements--;
@@ -2753,7 +2755,7 @@ public class FloatMatrix implements Serializable {
         FloatMatrix result = new FloatMatrix(rows, columns);
         int r = 0;
         while ((line = is.readLine()) != null) {
-            String[] elements = line.split("\\s+");
+            String[] elements = WHITESPACES.split(line);
             int firstElement = (elements[0].length() == 0) ? 1 : 0;
             for (int c = 0, cc = firstElement; c < columns; c++, cc++) {
                 result.put(r, c, Float.valueOf(elements[cc]));
@@ -2770,7 +2772,7 @@ public class FloatMatrix implements Serializable {
         String line;
         int columns = -1;
         while ((line = is.readLine()) != null) {
-            String[] elements = line.split(",");
+            String[] elements = COMMA.split(line);
             int numElements = elements.length;
             if (elements[0].length() == 0) {
                 numElements--;


### PR DESCRIPTION
Mikio I was noodling around the matrix code to see if I could optimize a bit the parts used in Spark MLlib. I found one non-trivial optimization that avoids an extra array allocation. I couldn't help fiddling with a few other things, which you can reject.

I'm also checking the appetite for some other optimizations that might involve adding a few more methods to the API (like an "increment value" method, and "self times transpose") but that's for another time.
