### PR TITLE
Recursion, hashCode issue and a few other suggestions

### DIFF
--- a/src/main/java/org/jblas/ComplexDouble.java
+++ b/src/main/java/org/jblas/ComplexDouble.java
@@ -302,7 +302,7 @@ public class ComplexDouble {
     }
     
     /**
-     * Comparing two DoubleComplex values.
+     * Comparing two ComplexDouble values.
      */
     public boolean equals(Object o) {
         if (!(o instanceof ComplexDouble)) {
@@ -310,7 +310,11 @@ public class ComplexDouble {
         }
         ComplexDouble c = (ComplexDouble) o;
 
-        return eq(c);
+        return r == c.r && i == c.i;
+    }
+
+    public int hashCode() {
+        return Double.valueOf(r).hashCode() ^ Double.valueOf(i).hashCode();
     }
 
     public boolean eq(ComplexDouble c) {

--- a/src/main/java/org/jblas/ComplexDoubleMatrix.java
+++ b/src/main/java/org/jblas/ComplexDoubleMatrix.java
@@ -43,6 +43,7 @@ import java.io.DataOutputStream;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.Arrays;
 
 public class ComplexDoubleMatrix {
 	
@@ -570,7 +571,7 @@ public class ComplexDoubleMatrix {
 	}
 
 	public ComplexDoubleMatrix putReal(ComplexDoubleMatrix rindices, ComplexDoubleMatrix cindices, double v) {
-		return putReal(rindices, cindices, v);
+		return putReal(rindices.findIndices(), cindices.findIndices(), v);
 	}
 
 	public ComplexDoubleMatrix putImag(ComplexDoubleMatrix rindices, ComplexDoubleMatrix cindices, double v) {
@@ -656,11 +657,13 @@ public class ComplexDoubleMatrix {
 
 		if (!sameSize(other))
 			return false;
-		
-		DoubleMatrix diff = MatrixFunctions.absi(sub(other)).getReal();
-		
-		return diff.max() / (rows * columns) < 1e-6;
+
+    return Arrays.equals(data, other.data);
 	}
+  
+  public int hashCode() {
+    return rows ^ columns ^ Arrays.hashCode(data);
+  }
 
 	
 	/** Resize the matrix. All elements will be set to zero. */
@@ -953,12 +956,7 @@ public class ComplexDoubleMatrix {
 	}
 
 	public double[] toDoubleArray() {
-		double[] array = new double[2*length];
-		
-		for (int i = 0; i < 2*length; i++)
-			array[i] = data[i];
-		
-		return array;
+		return data.clone();
 	}
 	
 	public ComplexDouble[] toArray() {

--- a/src/main/java/org/jblas/ComplexFloat.java
+++ b/src/main/java/org/jblas/ComplexFloat.java
@@ -302,7 +302,7 @@ public class ComplexFloat {
     }
     
     /**
-     * Comparing two DoubleComplex values.
+     * Comparing two ComplexFloat values.
      */
     public boolean equals(Object o) {
         if (!(o instanceof ComplexFloat)) {
@@ -310,7 +310,11 @@ public class ComplexFloat {
         }
         ComplexFloat c = (ComplexFloat) o;
 
-        return eq(c);
+        return r == c.r && i == c.i;
+    }
+
+    public int hashCode() {
+        return Float.valueOf(r).hashCode() ^ Float.valueOf(i).hashCode();
     }
 
     public boolean eq(ComplexFloat c) {

--- a/src/main/java/org/jblas/ComplexFloatMatrix.java
+++ b/src/main/java/org/jblas/ComplexFloatMatrix.java
@@ -43,6 +43,7 @@ import java.io.DataOutputStream;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.Arrays;
 
 public class ComplexFloatMatrix {
 	
@@ -570,7 +571,7 @@ public class ComplexFloatMatrix {
 	}
 
 	public ComplexFloatMatrix putReal(ComplexFloatMatrix rindices, ComplexFloatMatrix cindices, float v) {
-		return putReal(rindices, cindices, v);
+		return putReal(rindices.findIndices(), cindices.findIndices(), v);
 	}
 
 	public ComplexFloatMatrix putImag(ComplexFloatMatrix rindices, ComplexFloatMatrix cindices, float v) {
@@ -656,11 +657,13 @@ public class ComplexFloatMatrix {
 
 		if (!sameSize(other))
 			return false;
-		
-		FloatMatrix diff = MatrixFunctions.absi(sub(other)).getReal();
-		
-		return diff.max() / (rows * columns) < 1e-6;
+
+    return Arrays.equals(data, other.data);
 	}
+  
+  public int hashCode() {
+    return rows ^ columns ^ Arrays.hashCode(data);
+  }
 
 	
 	/** Resize the matrix. All elements will be set to zero. */
@@ -953,12 +956,7 @@ public class ComplexFloatMatrix {
 	}
 
 	public float[] toDoubleArray() {
-		float[] array = new float[2*length];
-		
-		for (int i = 0; i < 2*length; i++)
-			array[i] = data[i];
-		
-		return array;
+		return data.clone();
 	}
 	
 	public ComplexFloat[] toArray() {

--- a/src/main/java/org/jblas/FloatMatrix.java
+++ b/src/main/java/org/jblas/FloatMatrix.java
@@ -304,7 +304,8 @@ public class FloatMatrix implements Serializable {
      *
      **************************************************************************/
     /** Create a new matrix with <i>newRows</i> rows, <i>newColumns</i> columns
-     * using <i>newData></i> as the data. The length of the data is not checked!
+     * using <i>newData></i> as the data. Note that any change to the FloatMatrix
+     * will change the input array, too.
      */
     public FloatMatrix(int newRows, int newColumns, float... newData) {
         rows = newRows;
@@ -343,7 +344,11 @@ public class FloatMatrix implements Serializable {
     public FloatMatrix(int len) {
         this(len, 1, new float[len]);
     }
-
+    
+    /**
+     * Create a a row vector using <i>newData</i> as the data array.
+     * Note that any change to the created FloatMatrix will change in input array.
+     */
     public FloatMatrix(float[] newData) {
         this(newData.length, 1, newData);
     }
@@ -359,7 +364,9 @@ public class FloatMatrix implements Serializable {
 
     /**
      * Creates a new <i>n</i> times <i>m</i> <tt>FloatMatrix</tt> from
-     * the given <i>n</i> times <i>m</i> 2D data array. The first dimension of the array makes the
+     * the given <i>n</i> times <i>m</i> 2D data array. Note that the input array
+     * is copied and any change to the FloatMatrix will not change the input array.
+     * The first dimension of the array makes the
      * rows (<i>n</i>) and the second dimension the columns (<i>m</i>). For example, the
      * given code <br/><br/>
      * <code>new FloatMatrix(new float[][]{{1d, 2d, 3d}, {4d, 5d, 6d}, {7d, 8d, 9d}}).print();</code><br/><br/>

--- a/src/main/java/org/jblas/MatrixFunctions.java
+++ b/src/main/java/org/jblas/MatrixFunctions.java
@@ -35,8 +35,6 @@
 // --- END LICENSE BLOCK ---
 
 package org.jblas;
- 
-import java.lang.Math;
 
 /**
  * This class provides the functions from java.lang.Math for matrices. The

--- a/src/main/java/org/jblas/NativeBlas.java
+++ b/src/main/java/org/jblas/NativeBlas.java
@@ -35,8 +35,6 @@
 // --- END LICENSE BLOCK ---
 package org.jblas;
 
-import org.jblas.util.Logger;
-
 /**
  * Native BLAS and LAPACK functions.
  *

--- a/src/main/java/org/jblas/Solve.java
+++ b/src/main/java/org/jblas/Solve.java
@@ -36,8 +36,6 @@
 
 package org.jblas;
 
-import org.jblas.util.Functions;
-
 /**
  * Solving linear equations.
  */

--- a/src/main/java/org/jblas/ranges/AllRange.java
+++ b/src/main/java/org/jblas/ranges/AllRange.java
@@ -41,8 +41,6 @@
 
 package org.jblas.ranges;
 
-import org.jblas.*;
-
 /**
  * A range over all available indices. Can be used to address whole columns or rows. Like
  * the ":" index in matlab. Don't forget to call init() before using this range.

--- a/src/test/java/org/jblas/TestBlasDouble.java
+++ b/src/test/java/org/jblas/TestBlasDouble.java
@@ -39,7 +39,6 @@ package org.jblas;
 import org.junit.Test;
 
 import static org.jblas.MatrixFunctions.abs;
-import static org.jblas.MatrixFunctions.expi;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 

--- a/src/test/java/org/jblas/TestBlasFloat.java
+++ b/src/test/java/org/jblas/TestBlasFloat.java
@@ -39,7 +39,6 @@ package org.jblas;
 import org.junit.Test;
 
 import static org.jblas.MatrixFunctions.abs;
-import static org.jblas.MatrixFunctions.expi;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 

--- a/src/test/java/org/jblas/TestComplexFloat.java
+++ b/src/test/java/org/jblas/TestComplexFloat.java
@@ -40,6 +40,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class TestComplexFloat  {
 
@@ -73,11 +74,11 @@ public class TestComplexFloat  {
 	public void testMulAndDiv() {
 		ComplexFloat d = a.mul(b).div(b);
 		
-		assertEquals(new ComplexFloat(1.0f, 2.0f), d);
+		assertTrue(new ComplexFloat(1.0f, 2.0f).eq(d));
 		
 		d = a.mul(b).mul(b.inv());
 
-		assertEquals(new ComplexFloat(1.0f, 2.0f), d);
+		assertTrue(new ComplexFloat(1.0f, 2.0f).eq(d));
 	}
 
   @Test

--- a/src/test/java/org/jblas/TestDoubleMatrix.java
+++ b/src/test/java/org/jblas/TestDoubleMatrix.java
@@ -39,7 +39,6 @@ package org.jblas;
 import java.io.File;
 import java.io.PrintStream;
 
-import org.jblas.ranges.IntervalRange;
 import org.jblas.util.Random;
 
 import java.util.Arrays;
@@ -72,8 +71,8 @@ public class TestDoubleMatrix {
   public void testConstructionAndSetGet() {
     double[][] dataA = {{1.0, 5.0, 9.0}, {2.0, 6.0, 10.0}, {3.0, 7.0, 11.0}, {4.0, 8.0, 12.0}};
 
-    assertEquals(A.rows, 4);
-    assertEquals(A.columns, 3);
+    assertEquals(4, A.rows);
+    assertEquals(3, A.columns);
 
     for (int r = 0; r < 4; r++) {
       for (int c = 0; c < 3; c++) {

--- a/src/test/java/org/jblas/TestEigen.java
+++ b/src/test/java/org/jblas/TestEigen.java
@@ -40,8 +40,6 @@
  */
 package org.jblas;
 
-import junit.framework.TestCase;
-import org.jblas.util.Logger;
 import org.junit.Test;
 
 import static org.junit.Assert.*;

--- a/src/test/java/org/jblas/TestFloatMatrix.java
+++ b/src/test/java/org/jblas/TestFloatMatrix.java
@@ -39,7 +39,6 @@ package org.jblas;
 import java.io.File;
 import java.io.PrintStream;
 
-import org.jblas.ranges.IntervalRange;
 import org.jblas.util.Random;
 
 import java.util.Arrays;
@@ -71,8 +70,8 @@ public class TestFloatMatrix {
   public void testConstructionAndSetGet() {
     float[][] dataA = {{1.0f, 5.0f, 9.0f}, {2.0f, 6.0f, 10.0f}, {3.0f, 7.0f, 11.0f}, {4.0f, 8.0f, 12.0f}};
 
-    assertEquals(A.rows, 4);
-    assertEquals(A.columns, 3);
+    assertEquals(4, A.rows);
+    assertEquals(3, A.columns);
 
     for (int r = 0; r < 4; r++) {
       for (int c = 0; c < 3; c++) {

--- a/src/test/java/org/jblas/TestSolve.java
+++ b/src/test/java/org/jblas/TestSolve.java
@@ -36,10 +36,6 @@
 
 package org.jblas;
 
-import org.jblas.DoubleMatrix;
-import org.jblas.FloatMatrix;
-import org.jblas.Solve;
-import org.jblas.util.Random;
 import org.junit.*;
 import static org.junit.Assert.*;
 


### PR DESCRIPTION
Mikio I thought I'd suggest a few more things. This patch fixes what seems to be an inadvertent infinite recursion in ComplexDoubleMatrix.putReal; it just calls itself instead of the method that takes `int[]`. I also believe that equals() needs to be defined to be transitive, so needs exact-equality semantics, and needs a hashCode() as well, in the Complex\* classes. What do you think?

I also put in a few changes from inspection along the way, like removing unused imports, avoiding a manual array copy, etc. Really small things.
